### PR TITLE
Feat: modal component 구현

### DIFF
--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -10,6 +10,7 @@ export const decorators = [
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <Story />
+      <div id="modal"></div>
     </ThemeProvider>
   ),
 ];

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "next": "12.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-focus-lock": "^2.9.1",
     "styled-components": "^5.3.5",
     "styled-normalize": "^8.0.7"
   },

--- a/client/src/__tests__/components/modal.test.tsx
+++ b/client/src/__tests__/components/modal.test.tsx
@@ -1,0 +1,152 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../test-utils';
+
+import { Modal, ConfimationModal } from '~components/modal';
+
+import { useToggle } from '~hooks/index';
+
+interface TestProps {
+  withCancel?: boolean;
+}
+
+const TestComponent = ({ withCancel }: TestProps) => {
+  const [isOpen, toggle] = useToggle();
+
+  return (
+    <>
+      <Modal title="modal test" isOpen={isOpen} onClose={toggle}>
+        <ConfimationModal
+          message="This is modal test"
+          onCancel={withCancel ? toggle : undefined}
+          onConfirm={toggle}
+        />
+      </Modal>
+      <button type="button" onClick={toggle} aria-label="show modal" />
+    </>
+  );
+};
+
+const portalSetup = () => {
+  const portalContainer = document.createElement('div');
+  portalContainer.setAttribute('id', 'modal');
+  document.body.appendChild(portalContainer);
+};
+
+const removePortalSetup = () => {
+  // eslint-disable-next-line testing-library/no-node-access
+  document.querySelectorAll('#modal').forEach((el) => el.remove());
+};
+
+const setup = ({ withCancel }: TestProps) => {
+  portalSetup();
+  const utils = render(<TestComponent withCancel={withCancel} />);
+  const openButton = screen.getByRole('button', { name: /show modal/i });
+
+  return { openButton, ...utils };
+};
+
+describe('Modal Component', () => {
+  afterEach(() => {
+    removePortalSetup();
+  });
+
+  it('should be render correctly', async () => {
+    const { openButton } = setup({});
+
+    expect(openButton).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should be shown when the button is clicked', async () => {
+    const { openButton } = setup({});
+
+    expect(openButton).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await userEvent.click(openButton);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+    expect(screen.getByText('modal test')).toBeInTheDocument();
+    expect(screen.getByText('This is modal test')).toBeInTheDocument();
+    expect(screen.getByTestId('backdrop')).toBeInTheDocument();
+  });
+
+  it('should be shown with confirmation buttons', async () => {
+    const { openButton } = setup({ withCancel: true });
+
+    await userEvent.click(openButton);
+
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /confirm/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('should be closed when you click close button', async () => {
+    const { openButton, getByRole } = setup({ withCancel: true });
+
+    await userEvent.click(openButton);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    const closeButton = getByRole('button', { name: /close/i });
+    await userEvent.click(closeButton);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should be closed when you click outside', async () => {
+    const { openButton, getByTestId } = setup({ withCancel: true });
+
+    await userEvent.click(openButton);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    const backdrop = getByTestId('backdrop');
+
+    await userEvent.click(backdrop);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should be closed when you press escape key', async () => {
+    const { openButton } = setup({ withCancel: true });
+
+    await userEvent.click(openButton);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await userEvent.keyboard(`{Escape}`);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should move the foucs to next tabbable element inside the modal when you press tab key', async () => {
+    const { openButton } = setup({ withCancel: true });
+
+    await userEvent.click(openButton);
+
+    expect(screen.getByRole('button', { name: /close/i })).toHaveFocus();
+
+    await userEvent.tab();
+    expect(screen.getByRole('button', { name: /cancel/i })).toHaveFocus();
+
+    await userEvent.tab();
+    expect(screen.getByRole('button', { name: /confirm/i })).toHaveFocus();
+
+    await userEvent.tab();
+    expect(screen.getByRole('button', { name: /close/i })).toHaveFocus();
+  });
+
+  it('should move the foucs to prev tabbable element inside the modal when you press shift+tab key', async () => {
+    const { openButton } = setup({ withCancel: true });
+
+    await userEvent.click(openButton);
+
+    expect(screen.getByRole('button', { name: /close/i })).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab/}{/Shift}');
+    expect(screen.getByRole('button', { name: /confirm/i })).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab/}{/Shift}');
+    expect(screen.getByRole('button', { name: /cancel/i })).toHaveFocus();
+
+    await userEvent.keyboard('{Shift>}{Tab/}{/Shift}');
+    expect(screen.getByRole('button', { name: /close/i })).toHaveFocus();
+  });
+});

--- a/client/src/components/common/button/button-base.ts
+++ b/client/src/components/common/button/button-base.ts
@@ -24,8 +24,8 @@ const ButtonBase = styled.button<ButtonStyle>`
   user-select: none;
   transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
 
-  &:focus {
-    outline: none;
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.blue};
   }
 
   &:disabled {

--- a/client/src/components/common/button/button-icon.ts
+++ b/client/src/components/common/button/button-icon.ts
@@ -9,6 +9,8 @@ import { pixelToRem } from '~utils/style-utils';
 const ICON_BUTTON_STYLES: Partial<Record<GlobalSizes, ReturnType<typeof css>>> =
   {
     small: css`
+      width: fit-content;
+      height: fit-content;
       padding: ${pixelToRem(8)};
       border-radius: 50%;
       background-color: ${({ theme }) => theme.colors.dark};
@@ -19,6 +21,8 @@ const ICON_BUTTON_STYLES: Partial<Record<GlobalSizes, ReturnType<typeof css>>> =
       }
     `,
     medium: css`
+      width: fit-content;
+      height: fit-content;
       padding: ${pixelToRem(12)};
       border-radius: 50%;
       background-color: ${({ theme }) => theme.colors.green};
@@ -29,6 +33,8 @@ const ICON_BUTTON_STYLES: Partial<Record<GlobalSizes, ReturnType<typeof css>>> =
       }
     `,
     large: css`
+      width: fit-content;
+      height: fit-content;
       padding: ${pixelToRem(18)};
       border: 2px solid ${({ theme }) => theme.colors.gray_100};
       background-color: ${({ theme }) => theme.colors.gray_100};

--- a/client/src/components/modal/confirmation-modal.tsx
+++ b/client/src/components/modal/confirmation-modal.tsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+
+import { Button } from '~components/common';
+
+import { pixelToRem } from '~utils/style-utils';
+
+interface ConfirmationModalProps {
+  message: string;
+  onCancel?: React.MouseEventHandler;
+  onConfirm?: React.MouseEventHandler;
+}
+
+const ConfirmationModal = ({
+  message,
+  onCancel,
+  onConfirm,
+}: ConfirmationModalProps) => {
+  return (
+    <>
+      <Message>{message}</Message>
+      <ConfirmationButtons>
+        {onCancel && (
+          <Button
+            type="button"
+            variant="outline"
+            color="gray"
+            size="x-small"
+            fullWidth
+            aria-label="cancel"
+            onClick={onCancel}
+          >
+            취소
+          </Button>
+        )}
+        {onConfirm && (
+          <Button
+            type="button"
+            size="x-small"
+            fullWidth
+            aria-label="confirm"
+            onClick={onConfirm}
+          >
+            확인
+          </Button>
+        )}
+      </ConfirmationButtons>
+    </>
+  );
+};
+
+const Message = styled.p`
+  margin: 0;
+  padding: 0 ${pixelToRem(20)};
+  text-align: center;
+`;
+
+const ConfirmationButtons = styled.footer`
+  display: flex;
+  column-gap: ${pixelToRem(16)};
+`;
+
+export default ConfirmationModal;

--- a/client/src/components/modal/index.ts
+++ b/client/src/components/modal/index.ts
@@ -1,0 +1,2 @@
+export { default as Modal } from './modal';
+export { default as ConfimationModal } from './confirmation-modal';

--- a/client/src/components/modal/modal.stories.tsx
+++ b/client/src/components/modal/modal.stories.tsx
@@ -1,0 +1,86 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Modal from './modal';
+import ConfirmationModal from './confirmation-modal';
+
+import { Button } from '~components/common';
+
+import { useToggle } from '~hooks/index';
+
+export default {
+  title: 'components/modal',
+  component: Modal,
+  decorators: [
+    (Story) => (
+      <div style={{ height: '200vh', width: '100vw' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as ComponentMeta<typeof Modal>;
+
+const Template: ComponentStory<typeof Modal> = ({
+  isOpen,
+  onClose,
+  ...args
+}) => {
+  const [isShown, toggleModal] = useToggle();
+
+  return (
+    <>
+      <Modal isOpen={isShown} onClose={toggleModal} {...args}>
+        <ConfirmationModal
+          message="인증번호가 발송되었습니다."
+          onConfirm={toggleModal}
+        />
+      </Modal>
+      <Button
+        type="button"
+        size="x-small"
+        onClick={toggleModal}
+        style={{ marginTop: '400px' }}
+      >
+        이메일 인증
+      </Button>
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  title: '이메일 인증',
+};
+
+const ConfirmTemplate: ComponentStory<typeof Modal> = ({
+  isOpen,
+  onClose,
+  children,
+  ...args
+}) => {
+  const [isShown, toggleModal] = useToggle();
+
+  return (
+    <>
+      <Modal isOpen={isShown} onClose={toggleModal} {...args}>
+        <ConfirmationModal
+          message="비밀번호를 변경하시겠습니까?"
+          onCancel={toggleModal}
+          onConfirm={toggleModal}
+        />
+      </Modal>
+      <Button
+        type="button"
+        size="x-small"
+        onClick={toggleModal}
+        style={{ marginTop: '400px' }}
+      >
+        비밀번호 변경
+      </Button>
+    </>
+  );
+};
+
+export const ConfirmDefault = ConfirmTemplate.bind({});
+ConfirmDefault.args = {
+  title: '아이디/비밀번호',
+};

--- a/client/src/components/modal/modal.tsx
+++ b/client/src/components/modal/modal.tsx
@@ -1,0 +1,113 @@
+import type { PropsWithChildren } from 'react';
+
+import { useEffect, useCallback } from 'react';
+import FocusLock from 'react-focus-lock';
+import styled from 'styled-components';
+
+import { Button } from '../common/button';
+import { Portal } from '~hocs/index';
+import CloseSVG from '~public/svgs/close.svg';
+
+import { pixelToRem } from '~utils/style-utils';
+
+interface ModalProps extends PropsWithChildren {
+  title: string;
+  isOpen: boolean;
+  onClose: (e?: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => void;
+}
+
+const Modal = ({ title, isOpen, onClose, children }: ModalProps) => {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent): void => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    },
+    [isOpen, onClose],
+  );
+
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? 'hidden' : 'unset';
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Portal>
+      <FocusLock>
+        <Container
+          role="dialog"
+          tabIndex={-1}
+          aria-modal="true"
+          aria-labelledby={title}
+        >
+          <Header>
+            <Title>{title}</Title>
+            <Button
+              type="button"
+              variant="icon"
+              aria-label="close"
+              data-dismiss="modal"
+              onClick={onClose}
+            >
+              <CloseSVG />
+            </Button>
+          </Header>
+          <Content>{children}</Content>
+        </Container>
+      </FocusLock>
+      <Backdrop data-testid="backdrop" onClick={onClose} />
+    </Portal>
+  );
+};
+
+const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: ${({ theme }) => `${theme.colors.dark}60`};
+  z-index: 999;
+`;
+
+const Container = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  flex-direction: column;
+  width: ${pixelToRem(320)};
+  padding: ${pixelToRem(16)};
+  border-radius: ${pixelToRem(10)};
+  background-color: ${({ theme }) => theme.colors.light};
+  color: ${({ theme }) => theme.colors.dark};
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+`;
+
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Title = styled.h4`
+  margin: ${pixelToRem(2)} 0 0 ${pixelToRem(6)};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: ${pixelToRem(48)};
+  max-height: ${pixelToRem(360)};
+  margin-top: ${pixelToRem(40)};
+`;
+
+export default Modal;

--- a/client/src/hocs/index.ts
+++ b/client/src/hocs/index.ts
@@ -1,3 +1,4 @@
 export { default as withStatus } from './with-status';
 export { default as withLabel } from './with-label';
 export { default as withField } from './with-field';
+export { default as Portal } from './portal';

--- a/client/src/hocs/portal.tsx
+++ b/client/src/hocs/portal.tsx
@@ -1,0 +1,25 @@
+import { useState, useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+
+interface PortalProps {
+  selector?: string;
+  children: React.ReactNode;
+}
+
+const Portal = ({ selector = '#modal', children }: PortalProps) => {
+  const containerRef = useRef<Element | null>();
+  const [mounted, setMounted] = useState<boolean>(false);
+
+  useEffect(() => {
+    containerRef.current = document.querySelector(selector);
+    setMounted(true);
+  }, [selector]);
+
+  if (!containerRef.current) {
+    return null;
+  }
+
+  return mounted ? ReactDOM.createPortal(children, containerRef.current) : null;
+};
+
+export default Portal;

--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -19,6 +19,7 @@ export default class MyDocument extends Document {
           />
         </Head>
         <body>
+          <div id="modal" />
           <Main />
           <NextScript />
         </body>

--- a/client/src/styles/global-style.ts
+++ b/client/src/styles/global-style.ts
@@ -13,7 +13,6 @@ const GlobalStyle = createGlobalStyle`
     padding: 0;
     font-family: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     text-size-adjust: none;
-    overflow: hidden;
   }
 
   a {

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -17,8 +17,8 @@ export const colors = {
   gray: '#dbdbdb',
   gray_500: '#9c9c9c',
   gray_700: '#707070',
-  white: '#fff',
-  dark: '#444',
+  white: '#ffffff',
+  dark: '#444444',
 };
 
 export const fontSizes = {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1105,7 +1105,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
   integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
@@ -5570,6 +5570,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 detect-package-manager@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/detect-package-manager/-/detect-package-manager-2.0.1.tgz#6b182e3ae5e1826752bfef1de9a7b828cffa50d8"
@@ -6638,6 +6643,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+focus-lock@^0.11.2:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.3.tgz#c094e8f109d780f56038abdeec79328fd56b627f"
+  integrity sha512-4n0pYcPTa/uI7Q66BZna61nRT7lDhnuJ9PJr6wiDjx4uStg491ks41y7uOG+s0umaaa+hulNKSldU9aTg9/yVg==
+  dependencies:
+    tslib "^2.0.3"
 
 focus-lock@^0.8.0:
   version "0.8.1"
@@ -10265,7 +10277,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10428,6 +10440,13 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+react-clientside-effect@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz#29f9b14e944a376b03fb650eed2a754dd128ea3a"
+  integrity sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+
 react-docgen-typescript@^2.1.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
@@ -10472,6 +10491,18 @@ react-error-boundary@^3.1.0:
   integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+react-focus-lock@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.1.tgz#094cfc19b4f334122c73bb0bff65d77a0c92dd16"
+  integrity sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.11.2"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.6"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
 
 react-inspector@^5.1.0:
   version "5.1.1"
@@ -12317,6 +12348,21 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use-sync-external-store@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## 📌 개요

> closed #13 

- 모달 컴포넌트를 구현합니다. 

## 🛠 작업 사항

- Modal 컴포넌트 구현
  - react-portal을 이용해 DOM의 계층 구조에 종속되지 않게 모달 컴포넌트를 렌더링 할 수 있도록 구현
  - 닫기 버튼, 외부 클릭 시 모달 닫기
  - esc 클릭 시 모달 닫기
  - 모달이 열릴 시에 scroll이 위로 올라가는 것 방지
  - react-focust-lock을 통해 모달 내부에 focus 유지
- Button 컴포넌트
  - 웹 접근성을 위해 버튼 컴포넌트의 outline 속성을 focus-visible을 통해 수정
  - 아이콘 버튼이 부모 컴포넌트의 크기에 맞춰지는 것 width, height: fit-content를 통해 수정
- global-style
  - html, body에 적용되어있는 불필요한 overflow 속성 제거
  - theme color의 hex 코드가 세 자리로 되어있는 것들 6자리로 통일


## 📝 요약

모달 컴포넌트 구현

## 📸 첨부

![화면 기록 2022-10-04 오후 4 40 21](https://user-images.githubusercontent.com/68905615/193762543-5c0a0437-3b33-4c33-8e1d-d209b9691700.gif)

