### PR TITLE
Feat: Breadcrumb 컴포넌트 구현

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
+    'storybook-addon-next-router',
   ],
   framework: '@storybook/react',
   core: {

--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import * as NextImage from 'next/image';
-
+import { RouterContext } from 'next/dist/shared/lib/router-context';
 import { ThemeProvider } from 'styled-components';
+
 import GlobalStyle from '~styles/global-style';
 import { theme } from '~styles/theme';
 
@@ -22,6 +23,9 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+  },
+  nextRouter: {
+    Provider: RouterContext.Provider,
   },
 };
 

--- a/client/package.json
+++ b/client/package.json
@@ -71,6 +71,7 @@
     "lint-staged": "^13.0.3",
     "node-mocks-http": "^1.11.0",
     "prettier": "^2.7.1",
+    "storybook-addon-next-router": "^4.0.0",
     "ts-jest": "^29.0.1",
     "typescript": "4.8.3"
   }

--- a/client/public/svgs/chevron-right-thick.svg
+++ b/client/public/svgs/chevron-right-thick.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="16" viewBox="0 0 10 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 14.2675L8 8.30688L2 2.34625" stroke="#DBDBDB" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/__tests__/components/breadcrumb.test.tsx
+++ b/client/src/__tests__/components/breadcrumb.test.tsx
@@ -1,0 +1,73 @@
+import type { NextRouter } from 'next/router';
+
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+import userEvent from '@testing-library/user-event';
+import { render, screen, mockNextRouter } from '../test-utils';
+
+import { Breadcrumb } from '~components/breadcrumb';
+import RightBracketSVG from '~public/svgs/chevron-right-thick.svg';
+
+const setup = (
+  router: NextRouter,
+  seperator: React.ReactNode = <RightBracketSVG />,
+) => {
+  const user = userEvent.setup();
+  const utils = render(
+    <RouterContext.Provider value={router}>
+      <Breadcrumb seperator={seperator} />
+    </RouterContext.Provider>,
+  );
+
+  const breadcrumbs = screen.getByLabelText('breadcrumbs');
+
+  return { breadcrumbs, user, ...utils };
+};
+
+describe('Breadcrumb component', () => {
+  it('shoule be rendered correctly', () => {
+    const mockRouter = mockNextRouter({
+      pathname: '/',
+      asPath: '/',
+      query: {},
+    });
+
+    const { breadcrumbs, getByText } = setup(mockRouter);
+
+    expect(breadcrumbs).toBeInTheDocument();
+    expect(getByText('홈')).toBeInTheDocument();
+  });
+
+  it('should be rendered according to the pathname', () => {
+    const mockRouter = mockNextRouter({
+      pathname: '/메뉴/[id]',
+      asPath: '/메뉴/전체 메뉴',
+      query: {
+        id: 'all',
+      },
+    });
+
+    const { breadcrumbs, getByText } = setup(mockRouter);
+
+    expect(breadcrumbs).toBeInTheDocument();
+    expect(getByText('홈')).toBeInTheDocument();
+    expect(getByText('메뉴')).toBeInTheDocument();
+    expect(getByText('전체 메뉴')).toBeInTheDocument();
+  });
+
+  it('should navigate accordingly', async () => {
+    const mockRouter = mockNextRouter({
+      pathname: '/menu/[id]',
+      asPath: '/menu/all',
+      query: {
+        id: 'all',
+      },
+    });
+
+    const { user, getByText } = setup(mockRouter);
+    const menuLink = getByText(/menu/i);
+
+    await user.click(menuLink);
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/menu', '/menu', {});
+  });
+});

--- a/client/src/__tests__/test-utils.tsx
+++ b/client/src/__tests__/test-utils.tsx
@@ -1,8 +1,44 @@
+import type { NextRouter } from 'next/router';
+import * as nextRouter from 'next/router';
 import React, { FC, ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import GlobalStyle from '~styles/global-style';
 import { theme } from '~styles/theme';
+
+const mockUseNextRouter = jest.spyOn(nextRouter, 'useRouter');
+
+const createMockedRouter = (overrides?: Partial<NextRouter>): NextRouter => ({
+  basePath: '',
+  route: '/',
+  pathname: '/',
+  query: {},
+  asPath: `/`,
+  push: jest.fn(() => Promise.resolve(true)),
+  replace: jest.fn(() => Promise.resolve(true)),
+  reload: jest.fn(),
+  back: jest.fn(),
+  prefetch: jest.fn(() => Promise.resolve()),
+  beforePopState: jest.fn(),
+  events: {
+    emit: jest.fn(),
+    on: jest.fn(),
+    off: jest.fn(),
+  },
+  isFallback: false,
+  isLocaleDomain: false,
+  isReady: true,
+  isPreview: false,
+  defaultLocale: 'ko',
+  ...overrides,
+});
+
+export const mockNextRouter = (overrides: Partial<NextRouter> = {}) => {
+  const mockRouter = createMockedRouter(overrides);
+  mockUseNextRouter.mockReturnValue(mockRouter);
+
+  return mockRouter;
+};
 
 const AllTheProviders: FC<{ children: React.ReactNode }> = ({ children }) => {
   return (

--- a/client/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/client/src/components/breadcrumb/breadcrumb-item.tsx
@@ -1,0 +1,38 @@
+import type { PropsWithChildren } from 'react';
+
+import Link from 'next/link';
+import styled from 'styled-components';
+
+interface BreadcrumbItemProps extends PropsWithChildren {
+  href: string;
+  isCurrent?: boolean;
+}
+
+const BreadcrumbItem = ({
+  href,
+  isCurrent,
+  children,
+  ...rest
+}: BreadcrumbItemProps) => {
+  return (
+    <li {...rest}>
+      <Link href={href} passHref>
+        <LinkItem
+          href="replace"
+          isCurrent={isCurrent}
+          aria-current={isCurrent ? 'page' : 'false'}
+        >
+          {children}
+        </LinkItem>
+      </Link>
+    </li>
+  );
+};
+
+const LinkItem = styled.a<{ isCurrent?: boolean }>`
+  font-size: ${({ theme }) => theme.fontSizes.medium};
+  color: ${({ theme, isCurrent }) =>
+    isCurrent ? theme.colors.green : theme.colors.gray_700};
+`;
+
+export default BreadcrumbItem;

--- a/client/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/client/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -1,0 +1,48 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Breadcrumb from './breadcrumb';
+import RightBracketSVG from '~public/svgs/chevron-right-thick.svg';
+
+export default {
+  title: 'components/breadcrumb',
+  component: Breadcrumb,
+} as ComponentMeta<typeof Breadcrumb>;
+
+const Template: ComponentStory<typeof Breadcrumb> = ({ ...args }) => {
+  return <Breadcrumb {...args} />;
+};
+
+export const Home = Template.bind({});
+Home.args = {
+  seperator: <RightBracketSVG />,
+};
+Home.parameters = {
+  path: '/',
+  asPath: '/',
+  query: {},
+};
+
+export const Menu = Template.bind({});
+Menu.args = {
+  seperator: <RightBracketSVG />,
+};
+Menu.parameters = {
+  nextRouter: {
+    path: '/메뉴/[id]',
+    asPath: '/메뉴/함박 메뉴',
+    query: {
+      id: '함박 메뉴',
+    },
+  },
+};
+
+export const Store = Template.bind({});
+Store.args = {
+  seperator: <RightBracketSVG />,
+};
+Store.parameters = {
+  nextRouter: {
+    path: '/매장 관리',
+    asPath: '/매장 관리',
+  },
+};

--- a/client/src/components/breadcrumb/breadcrumb.tsx
+++ b/client/src/components/breadcrumb/breadcrumb.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+import Breadcrumbs from './breadcrumbs';
+import BreadcrumbItem from './breadcrumb-item';
+
+interface BreadcrumbState {
+  href: string;
+  label: string;
+  isCurrent: boolean;
+}
+
+interface BreadcrumbProps {
+  seperator: React.ReactNode;
+}
+
+const Breadcrumb = ({ seperator }: BreadcrumbProps) => {
+  const router = useRouter();
+  const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbState[]>();
+
+  useEffect(() => {
+    const pathWithoutQuery = router.asPath.split('?')[0];
+    let pathArray = pathWithoutQuery.split('/');
+    pathArray.shift();
+
+    pathArray = pathArray.filter((path) => path !== '');
+
+    const currentBreadcrumbs = pathArray.map((path, index) => {
+      const href = `/${pathArray.slice(0, index + 1).join('/')}`;
+      return {
+        href,
+        label: path.charAt(0).toUpperCase() + path.slice(1),
+        isCurrent: index === pathArray.length - 1,
+      };
+    });
+
+    setBreadcrumbs(currentBreadcrumbs);
+  }, [router.asPath]);
+
+  return (
+    <Breadcrumbs seperator={seperator}>
+      <BreadcrumbItem href="/">홈</BreadcrumbItem>
+      {breadcrumbs &&
+        breadcrumbs.map(({ href, label, isCurrent }) => (
+          <BreadcrumbItem key={href} href={href} isCurrent={isCurrent}>
+            {label}
+          </BreadcrumbItem>
+        ))}
+    </Breadcrumbs>
+  );
+};
+
+export default Breadcrumb;

--- a/client/src/components/breadcrumb/breadcrumbs.tsx
+++ b/client/src/components/breadcrumb/breadcrumbs.tsx
@@ -1,0 +1,61 @@
+import React, { Children, PropsWithChildren } from 'react';
+
+import styled from 'styled-components';
+
+import { pixelToRem } from '~utils/style-utils';
+
+interface BreadcrumbProps extends PropsWithChildren {
+  seperator: React.ReactNode;
+}
+
+const Breadcrumbs = ({ seperator, children }: BreadcrumbProps) => {
+  const childrenArray = Children.toArray(children);
+
+  const childrenWithSeperator = childrenArray.map((child, index) => {
+    if (index !== childrenArray.length - 1) {
+      return (
+        // 사이트의 이동 경로는 순서가 정해져 있다.
+        // 리스트의 순서가 동일하게 유지되는 경우 인덱스를 키 값으로 사용해도 지장이 없다
+        // eslint-disable-next-line react/no-array-index-key
+        <React.Fragment key={index}>
+          {child}
+          <Seperator>{seperator}</Seperator>
+        </React.Fragment>
+      );
+    }
+
+    return child;
+  });
+
+  return (
+    <BreadcrumbWrapper aria-label="breadcrumbs">
+      <BreadcrumbList>{childrenWithSeperator}</BreadcrumbList>
+    </BreadcrumbWrapper>
+  );
+};
+
+const BreadcrumbWrapper = styled.nav`
+  margin: ${pixelToRem(32)} 0;
+
+  @media ${({ theme }) => theme.breakPoints.medium} {
+    margin: ${pixelToRem(16)} 0;
+  }
+
+  @media ${({ theme }) => theme.breakPoints.small} {
+    margin: ${pixelToRem(8)} 0;
+  }
+`;
+
+const BreadcrumbList = styled.ol`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: ${pixelToRem(16)};
+`;
+
+const Seperator = styled.span`
+  display: flex;
+  align-items: center;
+`;
+
+export default Breadcrumbs;

--- a/client/src/components/breadcrumb/index.ts
+++ b/client/src/components/breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export { default as Breadcrumb } from './breadcrumb';

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -16,7 +16,8 @@ export const colors = {
   gray_100: '#f8f8f8',
   gray: '#dbdbdb',
   gray_500: '#9c9c9c',
-  gray_700: '#707070',
+  gray_600: '#707070',
+  gray_700: '#666666',
   white: '#ffffff',
   dark: '#444444',
 };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11436,6 +11436,13 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
+storybook-addon-next-router@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/storybook-addon-next-router/-/storybook-addon-next-router-4.0.0.tgz#d0719e6e27cbd2c374d23fad821157f2b053b045"
+  integrity sha512-zaEo/RI9IXzxlaiWeFBMBkjxYabLZGFibD82xH9AcKYcN/5yZq7VKo+NckMuTVu2WBaCUR4jA/O+ftcrQEvvfA==
+  dependencies:
+    tslib "^2.3.0"
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -12043,7 +12050,7 @@ tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
## 📌 개요

> closed #15 

- 사이트의 이동 경로를 나타내는 Breadcrumb를 구현합니다. 

## 🛠 작업 사항

- Breadcrumb 컴포넌트 구현
- storybook에서 useRouter에 의한 Breadcrumb 컴포넌트의 렌더링 상태를 확인하기 위해
  - `storybook-addon-next-router` 설치 
  - `./storybook/main.js`에 의존성 추가
  - `./storybook/preview.js`의 paramters에 next의 RouterContext.Provider를 추가
- `theme color`에 breadcrumb 폰트 색상을 위해 `_gray600` 추가
- `useRouter`를 테스트하기위해 useRouter를 mock하는 `test-utils` 추가

## 📝 요약

- Breadcrumb 컴포넌트 구현 및 테스트

## 📸 첨부

<img width="300" alt="스크린샷 2022-10-07 오전 12 19 57" src="https://user-images.githubusercontent.com/68905615/194352481-1abbca56-2892-44c7-bde9-617e142b24a6.png">
