### PR TITLE
Feat:  캐러셀 컴포넌트 구현

### DIFF
--- a/client/src/__tests__/components/carousel.test.tsx
+++ b/client/src/__tests__/components/carousel.test.tsx
@@ -1,0 +1,169 @@
+import type { CarouselProps } from '~components/carousel/carousel';
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen, act, fireEvent, cleanup } from '../test-utils';
+
+import { Carousel, CarouselItem } from '~components/carousel';
+
+interface TestProps extends CarouselProps {
+  items?: string[];
+}
+
+const TestComponent = ({ items, ...rest }: TestProps) => {
+  return (
+    <Carousel {...rest}>
+      {items?.map((item) => (
+        <CarouselItem key={item}>{item}</CarouselItem>
+      ))}
+    </Carousel>
+  );
+};
+
+const setup = ({
+  items = ['Item 1', 'Item 2', 'Item 3'],
+  ...rest
+}: TestProps) => {
+  const user = userEvent.setup();
+  const utils = render(<TestComponent items={items} {...rest} />);
+  const carousel = screen.getByRole('region');
+  const track = screen.getByRole('list', { name: /slides/i });
+  const slides = screen.getAllByRole('tabpanel', { name: /\d of \d/i });
+  const prevButton = screen.getByRole('button', { name: /prev-button/i });
+  const nextButton = screen.getByRole('button', { name: /next-button/i });
+  const indicators = screen.getAllByRole('tab', { name: /slide/i });
+
+  return {
+    user,
+    carousel,
+    track,
+    slides,
+    prevButton,
+    nextButton,
+    indicators,
+    ...utils,
+  };
+};
+
+describe('Carousel component', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+    jest.spyOn(global, 'setInterval');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    cleanup();
+  });
+
+  it('should be rendered correctly', () => {
+    const { carousel, track, slides, prevButton, nextButton, indicators } =
+      setup({});
+
+    expect(carousel).toBeInTheDocument();
+    expect(track).toBeInTheDocument();
+    slides.forEach((slide) => expect(slide).toBeInTheDocument());
+    expect(prevButton).toBeInTheDocument();
+    expect(nextButton).toBeInTheDocument();
+    indicators.forEach((indicator) => expect(indicator).toBeInTheDocument());
+  });
+
+  it('should have three times the number of slides received', () => {
+    const { slides: fiveSlides } = setup({
+      items: ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5'],
+    });
+
+    expect(fiveSlides.length).toBe(15);
+  });
+
+  it('should set track width currectly', async () => {
+    const SLIDE_WIDTH = 400;
+    const SLIDE_COUNTS = 3;
+    const DEFAULT_MARGIN = 130;
+
+    const { track } = setup({ width: SLIDE_WIDTH });
+    const trackWidth = (SLIDE_WIDTH + DEFAULT_MARGIN * 2) * SLIDE_COUNTS * 3;
+
+    expect(track).toHaveAttribute('width', trackWidth.toString());
+  });
+
+  it('should remove and redefinition transition of track using setTimeout', () => {
+    setup({});
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not update slide width when width is received', () => {
+    setup({ width: 400 });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(setTimeout).toHaveBeenCalledTimes(0);
+  });
+
+  it('should move slide without animation using setTimeout', async () => {
+    const { prevButton, nextButton } = setup({});
+    const clickButton = (button: HTMLElement) => {
+      fireEvent.click(button);
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+    };
+
+    clickButton(nextButton);
+    expect(setTimeout).toHaveBeenCalledTimes(0);
+
+    clickButton(nextButton);
+    clickButton(nextButton);
+    expect(setTimeout).toHaveBeenCalledTimes(2);
+
+    clickButton(prevButton);
+    expect(setTimeout).toHaveBeenCalledTimes(4);
+
+    clickButton(prevButton);
+    clickButton(prevButton);
+    clickButton(prevButton);
+    expect(setTimeout).toHaveBeenCalledTimes(6);
+
+    clickButton(nextButton);
+    expect(setTimeout).toHaveBeenCalledTimes(8);
+  });
+
+  it('should prevent mousedown event when touch the buttons', () => {
+    const { prevButton, nextButton } = setup({});
+    const isPreventedPrev = fireEvent.touchEnd(prevButton);
+    const isPreventedNext = fireEvent.touchEnd(nextButton);
+
+    // 이벤트가 취소되면 false를 반환한다.
+    expect(isPreventedPrev).toBe(false);
+    expect(isPreventedNext).toBe(false);
+  });
+
+  it('should play slide automatically', () => {
+    setup({ autoplay: true, autoplayInterval: 1000 });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(setInterval).toHaveBeenCalledTimes(1);
+  });
+
+  it('should play slide reverse automatically', () => {
+    setup({ autoplay: true, autoplayInterval: 1000, autoplayReverse: true });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(setInterval).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/__tests__/hooks/use-interval.test.tsx
+++ b/client/src/__tests__/hooks/use-interval.test.tsx
@@ -6,7 +6,7 @@ describe('useInterval hook', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.spyOn(globalThis, 'setTimeout');
+    jest.spyOn(globalThis, 'setInterval');
   });
 
   afterEach(() => {

--- a/client/src/__tests__/hooks/use-interval.test.tsx
+++ b/client/src/__tests__/hooks/use-interval.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook, act } from '../test-utils';
+import { useInterval } from '~hooks/index';
+
+describe('useInterval hook', () => {
+  beforeAll(() => {});
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(globalThis, 'setTimeout');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should recieved callback and delay', () => {
+    const callback = jest.fn();
+    const delay = 1000;
+    renderHook(() => useInterval(callback, delay));
+
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call callback every delay time', () => {
+    const callback = jest.fn();
+    const delay = 1000;
+    renderHook(() => useInterval(callback, delay));
+
+    jest.advanceTimersByTime(2000);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not restart the timer, if you pass a new callback', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    let callback = callback1;
+
+    const { rerender } = renderHook(() => {
+      useInterval(callback, 1000);
+    });
+
+    jest.advanceTimersByTime(500);
+
+    callback = callback2;
+    rerender();
+
+    jest.advanceTimersByTime(500);
+    expect(callback1).toHaveBeenCalledTimes(0);
+    expect(callback2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cancel the current timer and start a new one, if you pass a new delay', () => {
+    const callback = jest.fn();
+    let delay = 500;
+
+    const { rerender } = renderHook(() => {
+      useInterval(callback, delay);
+    });
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    delay = 1000;
+    rerender();
+    jest.advanceTimersByTime(5000);
+    expect(callback).toHaveBeenCalledTimes(7);
+  });
+
+  it('should causes no change in the timer if passing the same parameters', () => {
+    const callback = jest.fn();
+
+    const { rerender } = renderHook(() => {
+      useInterval(callback, 1000);
+    });
+
+    jest.advanceTimersByTime(500);
+
+    rerender();
+
+    jest.advanceTimersByTime(500);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/__tests__/hooks/use-interval.test.tsx
+++ b/client/src/__tests__/hooks/use-interval.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '../test-utils';
+import { renderHook } from '../test-utils';
 import { useInterval } from '~hooks/index';
 
 describe('useInterval hook', () => {

--- a/client/src/components/carousel/carousel-item.tsx
+++ b/client/src/components/carousel/carousel-item.tsx
@@ -36,9 +36,11 @@ const CarouselItemWrapper = styled.li<CarouselItemProps>`
   justify-content: center;
   align-items: center;
   width: ${({ width }) => `${width}px`};
-  min-height: ${pixelToRem(438)};
+  height: 100%;
+  min-height: ${pixelToRem(200)};
   margin: ${({ margin }) => `0 ${margin}px`};
   user-select: none;
+  background-color: green;
 `;
 
 export default CarouselItem;

--- a/client/src/components/carousel/carousel-item.tsx
+++ b/client/src/components/carousel/carousel-item.tsx
@@ -1,0 +1,45 @@
+import type { PropsWithChildren } from 'react';
+
+import styled from 'styled-components';
+import { pixelToRem } from '~utils/style-utils';
+
+export interface CarouselItemProps extends PropsWithChildren {
+  id?: string;
+  width?: number;
+  margin?: number;
+  label?: string;
+}
+
+const CarouselItem = ({
+  id,
+  width,
+  margin,
+  label,
+  children,
+}: CarouselItemProps) => {
+  return (
+    <CarouselItemWrapper
+      id={id}
+      width={width}
+      margin={margin}
+      role="tabpanel"
+      aria-roledescription="slide"
+      aria-label={label}
+    >
+      {children}
+    </CarouselItemWrapper>
+  );
+};
+
+const CarouselItemWrapper = styled.li<CarouselItemProps>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: ${({ width }) => `${width}px`};
+  min-height: ${pixelToRem(438)};
+  margin: ${({ margin }) => `0 ${margin}px`};
+  user-select: none;
+  background-color: green;
+`;
+
+export default CarouselItem;

--- a/client/src/components/carousel/carousel-item.tsx
+++ b/client/src/components/carousel/carousel-item.tsx
@@ -39,7 +39,6 @@ const CarouselItemWrapper = styled.li<CarouselItemProps>`
   min-height: ${pixelToRem(438)};
   margin: ${({ margin }) => `0 ${margin}px`};
   user-select: none;
-  background-color: green;
 `;
 
 export default CarouselItem;

--- a/client/src/components/carousel/carousel-item.tsx
+++ b/client/src/components/carousel/carousel-item.tsx
@@ -40,7 +40,6 @@ const CarouselItemWrapper = styled.li<CarouselItemProps>`
   min-height: ${pixelToRem(200)};
   margin: ${({ margin }) => `0 ${margin}px`};
   user-select: none;
-  background-color: green;
 `;
 
 export default CarouselItem;

--- a/client/src/components/carousel/carousel.stories.tsx
+++ b/client/src/components/carousel/carousel.stories.tsx
@@ -1,15 +1,16 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import Carousel, { CarouselItem } from './carousel';
+import Carousel from './carousel';
+import CarouselItem from './carousel-item';
 
 export default {
   title: 'components/carousel',
   component: Carousel,
 } as ComponentMeta<typeof Carousel>;
 
-const Template: ComponentStory<typeof Carousel> = () => {
+const Template: ComponentStory<typeof Carousel> = ({ ...args }) => {
   return (
-    <Carousel width={window.innerWidth} margin={40}>
+    <Carousel {...args}>
       <CarouselItem>Item 1</CarouselItem>
       <CarouselItem>Item 2</CarouselItem>
       <CarouselItem>Item 3</CarouselItem>
@@ -18,3 +19,49 @@ const Template: ComponentStory<typeof Carousel> = () => {
 };
 
 export const Default = Template.bind({});
+
+export const WithWith = Template.bind({});
+WithWith.args = {
+  width: 150,
+};
+
+export const NonDraggable = Template.bind({});
+NonDraggable.args = {
+  draggable: false,
+};
+
+export const NonAutoPlay = Template.bind({});
+NonAutoPlay.args = {
+  autoplay: false,
+};
+
+export const NonButton = Template.bind({});
+NonButton.args = {
+  button: false,
+};
+
+export const NonIndicator = Template.bind({});
+NonIndicator.args = {
+  indicator: false,
+};
+
+export const Tablet = Template.bind({});
+Tablet.parameters = {
+  viewport: {
+    defaultViewport: 'tablet',
+  },
+};
+
+export const LargeMobile = Template.bind({});
+LargeMobile.parameters = {
+  viewport: {
+    defaultViewport: 'mobile2',
+  },
+};
+
+export const SmallMobile = Template.bind({});
+SmallMobile.parameters = {
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+};

--- a/client/src/components/carousel/carousel.stories.tsx
+++ b/client/src/components/carousel/carousel.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Carousel, { CarouselItem } from './carousel';
+
+export default {
+  title: 'components/carousel',
+  component: Carousel,
+} as ComponentMeta<typeof Carousel>;
+
+const Template: ComponentStory<typeof Carousel> = () => {
+  return (
+    <Carousel width={window.innerWidth} margin={40}>
+      <CarouselItem>Item 1</CarouselItem>
+      <CarouselItem>Item 2</CarouselItem>
+      <CarouselItem>Item 3</CarouselItem>
+    </Carousel>
+  );
+};
+
+export const Default = Template.bind({});

--- a/client/src/components/carousel/carousel.tsx
+++ b/client/src/components/carousel/carousel.tsx
@@ -110,7 +110,7 @@ const Carousel = ({
 
   const movePrev = useCallback(
     (e?: MouseAndTouchEvent<HTMLButtonElement>) => {
-      if (e) {
+      if (e && 'touches' in e) {
         e.preventDefault();
       }
 
@@ -125,7 +125,7 @@ const Carousel = ({
 
   const moveNext = useCallback(
     (e?: MouseAndTouchEvent<HTMLButtonElement>) => {
-      if (e) {
+      if (e && 'touches' in e) {
         e.preventDefault();
       }
 
@@ -290,7 +290,7 @@ const Carousel = ({
         onTouchEnd={handleDragEnd}
         onMouseLeave={handleDragEnd}
         aria-label="slides"
-        aria-live="off"
+        aria-live={paused ? 'polite' : 'off'}
       >
         {React.Children.map(makeSlideClone(), (child, index) =>
           React.cloneElement(

--- a/client/src/components/carousel/carousel.tsx
+++ b/client/src/components/carousel/carousel.tsx
@@ -1,0 +1,233 @@
+import type { MutableRefObject, PropsWithChildren, ReactElement } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import styled, { css } from 'styled-components';
+import { Button } from '~components/common';
+import LeftArrowSVG from '~public/svgs/chevron-left.svg';
+import RightArrowSVG from '~public/svgs/chevron-right.svg';
+
+interface CarouselItemProps extends PropsWithChildren {
+  width?: number;
+  margin?: number;
+}
+
+export const CarouselItem = ({
+  width,
+  margin,
+  children,
+}: CarouselItemProps) => {
+  return (
+    <CarouselItemWrapper width={width} margin={margin}>
+      {children}
+    </CarouselItemWrapper>
+  );
+};
+
+const CarouselItemWrapper = styled.div<CarouselItemProps>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: ${({ width }) => `${width}px`};
+  height: 200px;
+  margin: ${({ margin }) => `${margin}px`};
+  background-color: ${({ theme }) => theme.colors.green};
+  color: white;
+`;
+
+interface CarouselProps extends PropsWithChildren {
+  width: number;
+  margin: number;
+}
+
+const Carousel = ({ width, margin, children }: CarouselProps) => {
+  const carouselRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const originSlideCount = useRef(React.Children.count(children));
+
+  const [currentIndex, setCurrentIndex] = useState(originSlideCount.current);
+  const [slideWidth, setSlideWidth] = useState(width - margin * 2);
+  const [paused, setPaused] = useState(false);
+
+  const slideCount = useRef(originSlideCount.current);
+  const translateDistance = useRef(slideWidth + margin * 2);
+  const stopTimerRef: MutableRefObject<NodeJS.Timer | null> = useRef(null);
+  const playTimerRef: MutableRefObject<NodeJS.Timer | null> = useRef(null);
+
+  const switchSlideIndexWithoutAnimation = (slideIndex: number) => {
+    stopTimerRef.current = setTimeout(() => {
+      if (!trackRef.current) {
+        return;
+      }
+
+      trackRef.current.style.transition = 'none';
+      setCurrentIndex(slideIndex);
+    }, 300);
+  };
+
+  const resetOriginAnimation = () => {
+    playTimerRef.current = setTimeout(() => {
+      if (!trackRef.current) {
+        return;
+      }
+
+      trackRef.current.style.transition = 'transform 300ms';
+    }, 400);
+  };
+
+  const movePrev = useCallback(() => {
+    setCurrentIndex((prev) => prev - 1);
+
+    if (currentIndex === originSlideCount.current - 1) {
+      switchSlideIndexWithoutAnimation(slideCount.current - 2);
+      resetOriginAnimation();
+    }
+  }, [currentIndex]);
+
+  const moveNext = useCallback(() => {
+    setCurrentIndex((prev) => prev + 1);
+
+    if (currentIndex === slideCount.current - 2) {
+      switchSlideIndexWithoutAnimation(originSlideCount.current - 1);
+      resetOriginAnimation();
+    }
+  }, [currentIndex]);
+
+  const updateIndex = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const target = e.currentTarget;
+    setCurrentIndex(Number(target.value));
+  };
+
+  const handleMouseEnter = () => {
+    setPaused(true);
+  };
+
+  const handleMouseLeave = () => {
+    setPaused(false);
+  };
+
+  // const updateSlideWidth = () => {
+  //   if (!carouselRef.current) {
+  //     return;
+  //   }
+
+  //   setSlideWidth(carouselRef.current.offsetWidth - margin);
+  // };
+
+  // const setTrackInitialPosition = useCallback(() => {
+  //   if (!trackRef.current || !carouselRef.current) {
+  //     return;
+  //   }
+
+  //   console.dir(trackRef.current);
+  //   const leftValue = trackRef.current.style.width - carouselRef.current.offsetWidth;
+  //   console.log(translatedValue);
+  //   trackRef.current.style.left = `-${leftValue}px`;
+  //   trackRef.current.style.left = '50%';
+  // }, [width]);
+
+  const makeSlideClones = () => {
+    if (!trackRef.current) {
+      return;
+    }
+
+    const slides = [...trackRef.current.children];
+    slides.forEach((slide) => {
+      const cloneSlide = slide.cloneNode(true);
+      trackRef.current?.appendChild(cloneSlide);
+    });
+    slides.reverse().forEach((slide) => {
+      const cloneSlide = slide.cloneNode(true);
+      trackRef.current?.prepend(cloneSlide);
+    });
+    slideCount.current = trackRef.current.children.length;
+  };
+
+  useEffect(() => {
+    makeSlideClones();
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!paused) {
+        moveNext();
+      }
+    }, 1000);
+
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  }, [paused, moveNext]);
+
+  return (
+    <Container
+      ref={carouselRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <Track ref={trackRef} distance={currentIndex * translateDistance.current}>
+        {React.Children.map(children, (child) => {
+          return React.cloneElement(
+            child as ReactElement<PropsWithChildren<CarouselItemProps>>,
+            {
+              width: slideWidth,
+              margin,
+            },
+          );
+        })}
+      </Track>
+      <Indicators>
+        <Button type="button" variant="icon" size="medium" onClick={movePrev}>
+          <LeftArrowSVG />
+        </Button>
+        {React.Children.map(children, (child, index) => (
+          <Indicator
+            type="button"
+            value={index}
+            isCurrent={currentIndex % originSlideCount.current === index}
+            onClick={updateIndex}
+          >
+            {index + 1}
+          </Indicator>
+        ))}
+        <Button type="button" variant="icon" size="medium" onClick={moveNext}>
+          <RightArrowSVG />
+        </Button>
+      </Indicators>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const Track = styled.div<{ distance: number }>`
+  position: relative;
+  margin: 0 auto;
+  transform: ${({ distance }) => `translateX(-${distance}px)`};
+  transition: transform 300ms;
+  white-space: nowrap;
+`;
+
+const Indicators = styled.div`
+  display: flex;
+  justify-content: center;
+
+  button {
+    margin: 5px;
+  }
+`;
+
+const Indicator = styled.button<{ isCurrent: boolean }>`
+  ${({ theme, isCurrent }) =>
+    isCurrent &&
+    css`
+      background-color: ${theme.colors.green};
+      color: white;
+    `}
+`;
+
+export default Carousel;

--- a/client/src/components/carousel/carousel.tsx
+++ b/client/src/components/carousel/carousel.tsx
@@ -377,6 +377,7 @@ const Track = styled.ul<{
   // left 값으로 초기 포지션을 조절해줘야 슬라이드가 두개 일때도 밀리지 않고 제대로 이동 가능
   left: ${({ initialPosition }) => pixelToRem(initialPosition)};
   width: ${({ width }) => pixelToRem(width)};
+  height: 100%;
   margin-block-start: 0;
   margin-block-end: 0;
   padding-inline-start: 0;

--- a/client/src/components/carousel/index.ts
+++ b/client/src/components/carousel/index.ts
@@ -1,0 +1,1 @@
+export { default as Carousel } from './carousel';

--- a/client/src/components/carousel/index.ts
+++ b/client/src/components/carousel/index.ts
@@ -1,1 +1,2 @@
 export { default as Carousel } from './carousel';
+export { default as CarouselItem } from './carousel-item';

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as useRipple } from './use-ripple';
 export { default as useInput } from './use-input';
 export { default as useToggle } from './use-toggle';
 export { default as useStopAnimationOnResize } from './use-stop-animation-on-resize';
+export { default as useInterval } from './use-interval';

--- a/client/src/hooks/use-interval.tsx
+++ b/client/src/hooks/use-interval.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+
+const useInterval = (callback: () => void, delay: number) => {
+  const intervalRef = useRef<number | null>(null);
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const timerId = window.setInterval(() => callbackRef.current(), delay);
+    intervalRef.current = timerId;
+
+    return () => clearInterval(timerId);
+  }, [delay]);
+
+  return intervalRef;
+};
+
+export default useInterval;

--- a/client/src/types/event.ts
+++ b/client/src/types/event.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export type MouseAndTouchEvent<T> = React.MouseEvent<T> | React.TouchEvent<T>;


### PR DESCRIPTION
## 📌 개요

> closed #30 

- 반응형 캐러셀을 구현합니다. 

## 🛠 작업 사항

- 반응형 구현
- 슬라이드 크기 및 여백 조절기능 구현
- 애니메이션 지속 기간 조절기능 구현
- 드래그 가능 여부 설정기능 구현
- 슬라이드 자동 재생 및 자동 재생 간격, 방향 조절기능 구현
- 버튼 및 현재 슬라이드 표시자(indicator) 기능 구현

## 📝 요약

carousel과 carousel-item 컴포넌트를 이용해 custom 반응형 캐러셀을 구현할 수 있는 컴포넌트를 구현했습니다. 

## 📸 첨부

## 구현 세부사항

- children을 전달하면 앞, 뒤로 동일한 개수의 슬라이드를 복제해서 생성합니다. 
- width를 전달받았다면 width가 고정되고, 화면 중앙에 위치시키기 위해 left 값을 이용합니다.
- width가 전달되지 않았다면, 화면 크기에 따른 slide의 크기가 조절됩니다. 
- button을 이용해서 슬라이드를 앞, 뒤로 이동 가능합니다.
- indicator 들을 클릭해서 원하는 번호의 슬라이드로 이동 가능합니다.
- 무한 슬라이드로 구현되어있으며, setTimeout을 이용해 transition을 잠시 제거해 슬라이드의 위치를 변경합니다. 
- 드래그를 통해 슬라이드를 이동할 수 있습니다. 
- 드래그 범위에 따라 슬라이드의 이동 개수가 달라집니다.
- 마우스가 캐러셀 위에 hover되면 자동 재생이 멈춥니다. 
- 반대로 자동 재생이 가능하며 자동 재생 시간 간격을 조절할 수 있습니다. 

## 기타 전달사항

요구사항 대로 테스트를 진행하고 싶은데, 테스트를 제대로 진행할 수 없었습니다. 테스트 코드에 대해 조금 더 공부하고 보완이 필요합니다. 
